### PR TITLE
Add Pending property page template

### DIFF
--- a/pending.property-page.json
+++ b/pending.property-page.json
@@ -1,0 +1,25 @@
+{
+  "providerId": "pending",
+  "providerName": "Pending",
+  "serviceId": "property-page",
+  "serviceName": "Property Page Hosting",
+  "version": 2,
+  "logoUrl": "https://trypending.com/logo.png",
+  "description": "Enables custom domain hosting for property pages.",
+  "variableDescription": "",
+  "records": [
+    {
+      "type": "CNAME",
+      "host": "www",
+      "pointsTo": "d1234567890.cloudfront.net",
+      "ttl": 3600
+    },
+    {
+      "type": "CNAME",
+      "host": "@",
+      "pointsTo": "d1234567890.cloudfront.net",
+      "ttl": 3600
+    }
+  ],
+  "syncRedirectDomain": "app.trypending.com"
+}

--- a/pending.property-page.json
+++ b/pending.property-page.json
@@ -11,13 +11,13 @@
     {
       "type": "CNAME",
       "host": "www",
-      "pointsTo": "d1234567890.cloudfront.net",
+      "pointsTo": "d269thkyr6dwzy.cloudfront.net",
       "ttl": 3600
     },
     {
       "type": "CNAME",
       "host": "@",
-      "pointsTo": "d1234567890.cloudfront.net",
+      "pointsTo": "d269thkyr6dwzy.cloudfront.net",
       "ttl": 3600
     }
   ],


### PR DESCRIPTION
# Description

Adds a new Domain Connect template for Pending property page hosting. This template enables users to point their custom domains to Pending property pages via CNAME records.

## Type of change

Please mark options that are relevant.

- [x] New template
- [ ] Bug fix (non-breaking change which fixes an issue in the template)
- [ ] New feature (non-breaking change which adds functionality to the template)
- [ ] Breaking change (fix or feature that would cause existing template behavior to be not backward compatible)

# How Has This Been Tested?

Please mark the following checks done
- [x] Schema validated using JSON Schema [template.schema](./template.schema)
- [x] Template functionality checked using [Online Editor](https://domainconnect.paulonet.eu/dc/free/templateedit)
- [x] Template is checked using [template linter](https://github.com/Domain-Connect/dc-template-linter)
- [x] Template file name follows the pattern `<providerId>.<serviceId>.json`

# Example variable values

This template creates CNAME records to point custom domains to Pending's CloudFront distribution for property page hosting.